### PR TITLE
Fix for problem where running npm-login-cmd with Powershell or comman…

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ if (!email) {
   process.exit(1);
 }
 
-const child = child_process.spawn("npm", ["login", "-q"], {
+const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+const child = child_process.spawn(npm, ["login", "-q"], {
   stdio: ["pipe", "pipe", "inherit"]
 });
 


### PR DESCRIPTION
…d prompt results in this error:

```
Error: spawn npm ENOENT
    at exports._errnoException (util.js:1050:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:367:16)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:427:7)
    at startup (bootstrap_node.js:151:9)
    at bootstrap_node.js:542:3
```
Fix for https://github.com/arian/npm-login-cmd/issues/1