### PR TITLE
Allow adding arguments to the npm login command

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,13 @@ if (!email) {
   process.exit(1);
 }
 
-const child = child_process.spawn("npm", ["login", "-q"], {
+const params = ["login", "-q"]
+if (process.env.NPM_EXTRA_ARGS) {
+  const extraArgs = JSON.parse(process.env.NPM_EXTRA_ARGS)
+  params.unshift(...extraArgs)
+}
+console.log(`Running with ${params}`)
+const child = child_process.spawn("npm", params, {
   stdio: ["pipe", "pipe", "inherit"]
 });
 


### PR DESCRIPTION
This allows passing extra arguments to the child `npm login` command.  In our case, npm9 changes authentication and we needed to pass this to npm via

`NPM_EXTRA_ARGS="[\"--auth-type=legacy\"]" npm-login-cmd`